### PR TITLE
Fix incorrect yarn add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ div(:component, data_qa: 'component')
 ### Install
 ```bash
 npm install --save-dev babel-plugin-transform-react-qa-classes
-# or yarn add -d
+# or yarn add -D
 ```
 
 ### Use


### PR DESCRIPTION
I found a typo in the yarn command example: `yarn add -d` is invalid. It can either be `yarn add -D` or `yarn add -dev`. 

I updated the README file to read `yarn add -D` to avoid confusion. 👍