### PR TITLE
Move babel-types to dependencies (used explicitly in style-components)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "travis-deploy-once": "travis-deploy-once"
   },
   "dependencies": {
+    "babel-types": "^6.26.0",
     "lodash.camelcase": "^4.3.0",
     "lodash.isstring": "^4.0.1",
     "lodash.kebabcase": "^4.1.1",
@@ -45,7 +46,6 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
-    "babel-types": "^6.26.0",
     "eslint-config-davesnx-rules": "^1.0.0",
     "husky": "^1.1.2",
     "mocha": "^3.1.2",


### PR DESCRIPTION
I just pulled in the latest 1.3.1 to a clean build and got an error for `babel-types` not found. The new `styled-components` file is using babel-types explicitly, so we need to move it from dev to standard dependencies.