### PR TITLE
Update README.md - remove supports fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Works with:
 - styled-components
 - arrow components
 - without JSX
-- supports fragments
 - option to configure the attribute name (default `data-qa`)
 - formats different the value of the attribute (default `camelCase`)
 


### PR DESCRIPTION
This plugin does not support fragments.
https://github.com/davesnx/babel-plugin-transform-react-qa-classes/issues/15